### PR TITLE
Extend EnhanceApiReq with generic

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,8 @@ export type EnhanceApiReq = {
 	method: string;
 	/** Root-relative path of the HTTP request URL */
 	path: string;
+	/** Application state from previous API middleware */
+	state?: Record<string, any>;
 };
 
 type EnhanceApiResBase = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
-export type EnhanceApiReq = {
+type EnhanceApiReqBase = {
 	/** The parsed JSON payload */
-	body: Record<string, any>;
+	body: Record<string, unknown>;
 	/** HTTP request headers as an object */
 	headers: Record<string, string>;
 	/** URL params (e.g. ‘cat’ in /app/api/cats/$cat.mjs) */
@@ -8,20 +8,22 @@ export type EnhanceApiReq = {
 	/** HTTP request querystring parameters as an object */
 	query: Record<string, string>;
 	/** HTTP request cookie as an object */
-	session: Record<string, any>;
+	session: Record<string, unknown>;
 	/** HTTP request method: GET, POST, PATCH, PUT, or DELETE */
 	method: string;
 	/** Root-relative path of the HTTP request URL */
 	path: string;
-	/** Application state from previous API middleware */
-	state?: Record<string, any>;
 };
+
+export type EnhanceApiReq =
+	& EnhanceApiReqBase
+	& (Record<string, unknown>)
 
 type EnhanceApiResBase = {
 	/** HTTP response headers as an object */
 	headers?: Record<string, string>;
 	/** Writes passed object to the session */
-	session?: Record<string, any>;
+	session?: Record<string, unknown>;
 	/* Redirect path, when statusCode is 301 or 302 */
 	location?: string;
 	/** HTTP response status. Defaults to 200. */
@@ -48,7 +50,7 @@ type EnhanceApiResBase = {
 
 type EnhanceApiResJson = {
 	/** JSON response, or initial state for a corresponding page */
-	json?: Record<string, any>;
+	json?: Record<string, unknown>;
 	/** body is incompatible when json is specified */
 	body?: never;
 };
@@ -81,11 +83,11 @@ export type EnhanceElemArg = {
 		/** HTML element attributes as an object */
 		attrs: Record<string, string>;
 		/** Initial state data passed to all Enhance elements */
-		store: Record<string, any>;
+		store: Record<string, unknown>;
 		/** Unique ID for this instance of the element */
 		instanceID: string;
 		/** Context data passed to this Enhance element */
-		context: Record<string, any>;
+		context: Record<string, unknown>;
 	};
 };
 
@@ -104,7 +106,7 @@ export type EnhanceHeadFnArg = {
 	/** Error message, present when status is 404 or 500 */
 	error?: string;
 	/** Initial state data passed to all Enhance elements */
-	store: Record<string, any>;
+	store: Record<string, unknown>;
 };
 
 export type EnhanceHeadFn = (arg0: EnhanceHeadFnArg) => EnhanceElemResult;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 type EnhanceApiReqBase = {
 	/** The parsed JSON payload */
-	body: Record<string, unknown>;
+	body: Record<string, any>;
 	/** HTTP request headers as an object */
 	headers: Record<string, string>;
 	/** URL params (e.g. ‘cat’ in /app/api/cats/$cat.mjs) */
@@ -8,7 +8,7 @@ type EnhanceApiReqBase = {
 	/** HTTP request querystring parameters as an object */
 	query: Record<string, string>;
 	/** HTTP request cookie as an object */
-	session: Record<string, unknown>;
+	session: Record<string, any>;
 	/** HTTP request method: GET, POST, PATCH, PUT, or DELETE */
 	method: string;
 	/** Root-relative path of the HTTP request URL */
@@ -17,13 +17,13 @@ type EnhanceApiReqBase = {
 
 export type EnhanceApiReq =
 	& EnhanceApiReqBase
-	& (Record<string, unknown>)
+	& (Record<string, any>)
 
 type EnhanceApiResBase = {
 	/** HTTP response headers as an object */
 	headers?: Record<string, string>;
 	/** Writes passed object to the session */
-	session?: Record<string, unknown>;
+	session?: Record<string, any>;
 	/* Redirect path, when statusCode is 301 or 302 */
 	location?: string;
 	/** HTTP response status. Defaults to 200. */
@@ -50,7 +50,7 @@ type EnhanceApiResBase = {
 
 type EnhanceApiResJson = {
 	/** JSON response, or initial state for a corresponding page */
-	json?: Record<string, unknown>;
+	json?: Record<string, any>;
 	/** body is incompatible when json is specified */
 	body?: never;
 };
@@ -83,11 +83,11 @@ export type EnhanceElemArg = {
 		/** HTML element attributes as an object */
 		attrs: Record<string, string>;
 		/** Initial state data passed to all Enhance elements */
-		store: Record<string, unknown>;
+		store: Record<string, any>;
 		/** Unique ID for this instance of the element */
 		instanceID: string;
 		/** Context data passed to this Enhance element */
-		context: Record<string, unknown>;
+		context: Record<string, any>;
 	};
 };
 
@@ -106,7 +106,7 @@ export type EnhanceHeadFnArg = {
 	/** Error message, present when status is 404 or 500 */
 	error?: string;
 	/** Initial state data passed to all Enhance elements */
-	store: Record<string, unknown>;
+	store: Record<string, any>;
 };
 
 export type EnhanceHeadFn = (arg0: EnhanceHeadFnArg) => EnhanceElemResult;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -18,7 +18,7 @@ type Todo = {
 export const get: EnhanceApiFn = function (request) {
 	console.log(`Handling ${request.path}...`);
 
-	const filter: string = request.body.filter;
+	const filter: string = request.body.filter as string;
 
 	const todos: Todo[] = [
 		{ title: "todo 1", completed: false },


### PR DESCRIPTION
small change, but I extended  `EnhanceApiReq` with a generic type so that API "middleware" can attach things to `req` in order to pass to subsequent handlers.

Better demonstrated with code:

```js
// some middleware to pick a random emoji on each GET
async function randomEmoji (req) {
  const emojis = ['🛻', '🏔️', '🎮', '🦬', '⚾️']
  req.icon = emojis[emojis.length * Math.random() | 0]
}

/** @type {import('@enhance/types').EnhanceApiFn} */
async function getHandler({ icon = '😵' }) { // <-- this won't have a type error with my change
  return {
    json: { icon },
  }
}

export const get = [randomEmoji, getHandler]
```

not a major but probably a minor release

---

note: I did flail a little with the implementation here experimenting with `unknown` vs `any` but I think it ends up putting more burden on even the strictest Typescripters.